### PR TITLE
Fix for unparseable date

### DIFF
--- a/src/main/java/net/oneandone/maven/plugins/prerelease/Locksmith.java
+++ b/src/main/java/net/oneandone/maven/plugins/prerelease/Locksmith.java
@@ -110,7 +110,7 @@ public class Locksmith extends Base {
 
     private static final SimpleDateFormat TODAY = new SimpleDateFormat("HH:mm:ss");
     private static final SimpleDateFormat OTHER = new SimpleDateFormat("MMM dd", Locale.US);
-    private static final SimpleDateFormat MAC = new SimpleDateFormat("EEE MMM d HH:mm:ss yyyy");
+    private static final SimpleDateFormat MAC = new SimpleDateFormat("EEE MMM dd HH:mm:ss yyyy");
 
     private Map<String, Long> startedMap() throws IOException {
         String[] cmd;


### PR DESCRIPTION
See occurred exception: 

```
[ERROR] Failed to execute goal net.oneandone.maven.plugins:prerelease:1.6.3:locksmith (default-cli) on project standalone-pom: Execution default-cli of goal net.oneandone.maven.plugins:prerelease:1.6.3:locksmith failed: invalid date in line 1 Tue Aug 26 17:21:53 2014: Unparseable date: "Tue Aug 26 17:21:53 2014" -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal net.oneandone.maven.plugins:prerelease:1.6.3:locksmith (default-cli) on project standalone-pom: Execution default-cli of goal net.oneandone.maven.plugins:prerelease:1.6.3:locksmith failed: invalid date in line 1 Tue Aug 26 17:21:53 2014
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:224)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:120)
    at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:347)
    at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:154)
    at org.apache.maven.cli.MavenCli.execute(MavenCli.java:584)
    at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:213)
    at org.apache.maven.cli.MavenCli.main(MavenCli.java:157)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:483)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: org.apache.maven.plugin.PluginExecutionException: Execution default-cli of goal net.oneandone.maven.plugins:prerelease:1.6.3:locksmith failed: invalid date in line 1 Tue Aug 26 17:21:53 2014
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:143)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
    ... 19 more
Caused by: java.lang.IllegalStateException: invalid date in line 1 Tue Aug 26 17:21:53 2014
    at net.oneandone.maven.plugins.prerelease.Locksmith.startedMap(Locksmith.java:153)
    at net.oneandone.maven.plugins.prerelease.Locksmith.doExecute(Locksmith.java:69)
    at net.oneandone.maven.plugins.prerelease.Base.execute(Base.java:89)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:132)
    ... 20 more
Caused by: java.text.ParseException: Unparseable date: "Tue Aug 26 17:21:53 2014"
    at java.text.DateFormat.parse(DateFormat.java:366)
    at net.oneandone.maven.plugins.prerelease.Locksmith.startedMap(Locksmith.java:148)
    ... 23 more
```
